### PR TITLE
Refactor constructor in ImageService to properly parse source URL

### DIFF
--- a/src/Services/ImageService.php
+++ b/src/Services/ImageService.php
@@ -7,7 +7,10 @@ use League\Glide\Signatures\SignatureFactory;
 
 final class ImageService
 {
-    public function __construct(private string $src, private int $width, private int $height, private array $baseManipulations) {}
+    public function __construct(private string $src, private int $width, private int $height, private array $baseManipulations) 
+    {
+        $this->src = parse_url($src, PHP_URL_PATH) ?? $src;
+    }
 
     public function url(array $manipulations): string
     {

--- a/src/Services/ImageService.php
+++ b/src/Services/ImageService.php
@@ -7,9 +7,10 @@ use League\Glide\Signatures\SignatureFactory;
 
 final class ImageService
 {
-    public function __construct(private string $src, private int $width, private int $height, private array $baseManipulations) 
+    public function __construct(private string $src, private int $width, private int $height, private array $baseManipulations)
     {
-        $this->src = parse_url($src, PHP_URL_PATH) ?? $src;
+        $path = parse_url($src, PHP_URL_PATH);
+        $this->src = $path !== false ? $path : $src;
     }
 
     public function url(array $manipulations): string

--- a/src/Services/ImageService.php
+++ b/src/Services/ImageService.php
@@ -10,7 +10,7 @@ final class ImageService
     public function __construct(private string $src, private int $width, private int $height, private array $baseManipulations)
     {
         $path = parse_url($src, PHP_URL_PATH);
-        $this->src = $path !== false ? $path : $src;
+        $this->src = is_string($path) ? $path : $src;
     }
 
     public function url(array $manipulations): string


### PR DESCRIPTION
After upgrading Laravel I saw the following error: Disk [http:] does not have a configured driver.

I tried different approaches to see what was happening and the one thing that solved it was modifying the constructor:

``` php    
public function __construct(private string $src, private int $width, private int $height, private array $baseManipulations)
{
       $this->src = parse_url($src, PHP_URL_PATH) ?? $src;
}
```