### PR TITLE
Support more manipulations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: ['push', 'pull_request']
+on: ["push", "pull_request"]
 
 jobs:
   ci:
@@ -8,38 +8,37 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        php: ['8.3']
+        os: [ubuntu-latest]
+        php: ["8.3", "8.4", "8.5"]
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: Tests P${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, mbstring, zip
+          coverage: none
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php }}
-        extensions: dom, mbstring, zip
-        coverage: none
+      - name: Get Composer cache directory
+        id: composer-cache
+        shell: bash
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-    - name: Get Composer cache directory
-      id: composer-cache
-      shell: bash
-      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}
+          restore-keys: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-
 
-    - name: Cache dependencies
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.composer-cache.outputs.dir }}
-        key: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}
-        restore-keys: dependencies-php-${{ matrix.php }}-os-${{ matrix.os }}-version-${{ matrix.dependency-version }}-composer-
+      - name: Install Composer dependencies
+        run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
 
-    - name: Install Composer dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
-
-    - name: Integration Tests
-      run: php ./vendor/bin/pest
+      - name: Integration Tests
+        run: php ./vendor/bin/pest

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 
 ## Features
 
--   🖼️ **Responsive images**: Automatically generates and serves appropriately sized images for any device
--   🚀 **Performance optimized**: Converts images to modern formats like WebP for faster loading
--   📱 **Adaptive srcsets**: Creates optimized srcsets for both responsive and fixed-width images
--   🔍 **Placeholder support**: Includes "blur" and "empty" placeholder options while images load
--   ⚙️ **Highly configurable**: Customize quality, widths, and more to fit your needs
--   🛠️ **Simple API**: Clean Blade component syntax that feels natural in your Laravel views
+- 🖼️ **Responsive images**: Automatically generates and serves appropriately sized images for any device
+- 🚀 **Performance optimized**: Converts images to modern formats like WebP for faster loading
+- 📱 **Adaptive srcsets**: Creates optimized srcsets for both responsive and fixed-width images
+- 🔍 **Placeholder support**: Includes "blur" and "empty" placeholder options while images load
+- ⚙️ **Highly configurable**: Customize quality, widths, and more to fit your needs
+- 🛠️ **Simple API**: Clean Blade component syntax that feels natural in your Laravel views
 
 ## Installation
 
@@ -111,6 +111,30 @@ Use the Blade component in your views:
 />
 ```
 
+### Cropped Image
+
+```blade
+<x-opixlig::image
+    src="public/images/hero.jpg"
+    width="800"
+    height="600"
+    fit="crop-center"
+    alt="Center-cropped hero image"
+/>
+```
+
+### Additional Manipulations
+
+```blade
+<x-opixlig::image
+    src="public/images/hero.jpg"
+    width="800"
+    height="600"
+    :manipulations="['blur' => 10, 'bri' => 20]"
+    alt="Blurred and brightened hero image"
+/>
+```
+
 ### Using the Helper Function
 
 You can also use the `img()` helper function directly:
@@ -123,32 +147,61 @@ $imageUrl = img('public/images/hero.jpg', 800, 600, ['fm' => 'webp', 'q' => 80])
 
 ### Available Props
 
-| Prop        | Type   | Default                               | Description                                                                   |
-| ----------- | ------ | ------------------------------------- | ----------------------------------------------------------------------------- |
-| src         | string | ''                                    | Path to the source image (including disk name e.g., 'public/images/file.jpg') |
-| sizes       | string | ''                                    | Media query sizes attribute for responsive images                             |
-| width       | number | ''                                    | Width of the image                                                            |
-| height      | number | ''                                    | Height of the image                                                           |
-| loading     | string | 'lazy'                                | Image loading strategy ('lazy', 'eager', 'auto')                              |
-| decoding    | string | 'async'                               | Image decoding strategy ('async', 'sync', 'auto')                             |
-| quality     | number | config('opixlig.default_quality')     | Image quality (1-100)                                                         |
-| placeholder | string | config('opixlig.default_placeholder') | Placeholder type ('empty' or 'blur')                                          |
-| format      | string | config('opixlig.default_format')      | Image format ('jpg', 'pjpg', 'png', 'gif', 'webp', 'avif', 'heic'*). *heic only supported with Imagick driver |
+| Prop          | Type   | Default                               | Description                                                                                                                                                                                                               |
+| ------------- | ------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| src           | string | ''                                    | Path to the source image (including disk name e.g., 'public/images/file.jpg')                                                                                                                                             |
+| sizes         | string | ''                                    | Media query sizes attribute for responsive images                                                                                                                                                                         |
+| width         | number | ''                                    | Width of the image                                                                                                                                                                                                        |
+| height        | number | ''                                    | Height of the image                                                                                                                                                                                                       |
+| loading       | string | 'lazy'                                | Image loading strategy ('lazy', 'eager', 'auto')                                                                                                                                                                          |
+| decoding      | string | 'async'                               | Image decoding strategy ('async', 'sync', 'auto')                                                                                                                                                                         |
+| quality       | number | config('opixlig.default_quality')     | Image quality (1-100)                                                                                                                                                                                                     |
+| placeholder   | string | config('opixlig.default_placeholder') | Placeholder type ('empty' or 'blur')                                                                                                                                                                                      |
+| format        | string | config('opixlig.default_format')      | Image format ('jpg', 'pjpg', 'png', 'gif', 'webp', 'avif', 'heic'*). *heic only supported with Imagick driver                                                                                                             |
+| fit           | string | ''                                    | How the image is fitted to its target dimensions. Values: 'contain', 'max', 'fill', 'fill-max', 'stretch', 'crop'. For crop positioning, use e.g. 'crop-center', 'crop-top', or Statamic focal points like 'crop-44-13-1' |
+| manipulations | array  | []                                    | Additional [Glide manipulations](https://glide.thephpleague.com/2.0/api/quick-reference/) as key-value pairs                                                                                                              |
 
 ### Image Manipulations
 
-Opixlig uses [League's Glide](https://glide.thephpleague.com/) under the hood, so you can pass any Glide manipulation parameters:
+The `fit` prop covers the most common resize/crop use cases (including Statamic focal point crops like `fit="crop-44-13-1"`), but you can pass any [Glide manipulation parameter](https://glide.thephpleague.com/2.0/api/quick-reference/) via the `manipulations` prop:
+
+```blade
+<x-opixlig::image
+    src="public/images/hero.jpg"
+    width="800"
+    height="600"
+    fit="crop-center"
+    :manipulations="['sharp' => 50, 'filt' => 'greyscale']"
+    alt="Cropped greyscale hero"
+/>
+```
+
+All supported Glide manipulations:
+
+| Parameter   | Key      | Description                                                |
+| ----------- | -------- | ---------------------------------------------------------- |
+| Width       | `w`      | Width in pixels (set via `width` prop)                     |
+| Height      | `h`      | Height in pixels (set via `height` prop)                   |
+| Fit         | `fit`    | Resize method (set via `fit` prop)                         |
+| Crop        | `crop`   | Pixel-based crop: 'width,height,x,y' (via `manipulations`) |
+| Quality     | `q`      | Image quality, 0-100 (set via `quality` prop)              |
+| Format      | `fm`     | Output format (set via `format` prop)                      |
+| Blur        | `blur`   | Blur amount (0-100)                                        |
+| Sharpen     | `sharp`  | Sharpen amount (0-100)                                     |
+| Brightness  | `bri`    | Brightness adjustment (-100 to 100)                        |
+| Contrast    | `con`    | Contrast adjustment (-100 to 100)                          |
+| Gamma       | `gam`    | Gamma adjustment (0.1 to 9.99)                             |
+| Pixelate    | `pixel`  | Pixelate amount (0-1000)                                   |
+| Filter      | `filt`   | Filter ('greyscale', 'sepia')                              |
+| Flip        | `flip`   | Flip ('h', 'v', 'both')                                    |
+| Orientation | `or`     | Rotation ('auto', '90', '180', '270')                      |
+| Background  | `bg`     | Background color (hex, e.g. 'fff')                         |
+| Border      | `border` | Border ('width,color,method')                              |
+
+You can also use the `img()` helper function directly:
 
 ```php
-$imageUrl = img('public/images/hero.jpg', 800, 600)
-    ->url([
-        'w' => 800,               // Width
-        'q' => 90,                // Quality
-        'fm' => 'webp',           // Format (jpg, pjpg, png, gif, webp, avif, heic)
-        'fit' => 'crop',          // Fit
-        'crop' => 'center',       // Crop position
-        // Other Glide parameters...
-    ]);
+$imageUrl = img('public/images/hero.jpg', 800, 600, ['fm' => 'webp', 'q' => 80])->url(['w' => 800]);
 ```
 
 ## How It Works

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.18.1",
+        "orchestra/testbench": "^10.2",
         "pestphp/pest": "^3.5.1",
         "pestphp/pest-plugin-type-coverage": "^3.1",
         "phpstan/phpstan": "^1.12.7",

--- a/resources/views/components/image.blade.php
+++ b/resources/views/components/image.blade.php
@@ -26,9 +26,9 @@
     $imgService = img($src, $width, $height, $baseManipulations);
 
     if ($sizes) {
-        $srcSet = collect($defaultWidths)->map(fn($w) => $imgService->url(['w' => $w]) . " {$w}w")->implode(', ');
+        $srcSet = collect($defaultWidths)->map(fn($w) => $imgService->url(['w' => $w, 'h' => intval(round($w * $height / $width))]) . " {$w}w")->implode(', ');
 
-        $finalSrc = $imgService->url(['w' => max($defaultWidths)]);
+        $finalSrc = $imgService->url(['w' => max($defaultWidths), 'h' => intval(round(max($defaultWidths) * $height / $width))]);
         $attrs = [
             'srcset' => $srcSet,
             'src' => $finalSrc,
@@ -40,9 +40,9 @@
             2 => $width * 2,
         ];
 
-        $srcSet = collect($dprWidths)->map(fn($w, $dpr) => $imgService->url(['w' => $w]) . " {$dpr}x")->implode(', ');
+        $srcSet = collect($dprWidths)->map(fn($w, $dpr) => $imgService->url(['w' => $w, 'h' => $height * $dpr]) . " {$dpr}x")->implode(', ');
 
-        $finalSrc = $imgService->url(['w' => $width * 2]);
+        $finalSrc = $imgService->url(['w' => $width * 2, 'h' => $height * 2]);
         $attrs = [
             'src' => $finalSrc,
             'srcset' => $srcSet,

--- a/resources/views/components/image.blade.php
+++ b/resources/views/components/image.blade.php
@@ -8,12 +8,22 @@
     'quality' => config('opixlig.default_quality'),
     'placeholder' => config('opixlig.default_placeholder'), // empty or blur
     'format' => config('opixlig.default_format'), // webp, avif, png, jpg, gif or heic.
+    'fit' => '', // contain, max, fill, fill-max, stretch, crop, crop-center, crop-top, crop-50-50-1, etc.
+    'manipulations' => [], // Additional Glide manipulations. E.g. ['blur' => 50, 'filt' => 'greyscale'].
 ])
 
 @php
     $defaultWidths = config('opixlig.default_widths');
 
-    $imgService = img($src, $width, $height, ['fm' => $format, 'q' => $quality]);
+    $baseManipulations = array_filter([
+        'fm' => $format,
+        'q' => $quality,
+        'fit' => $fit,
+    ], fn ($value) => $value !== '' && $value !== null);
+
+    $baseManipulations = array_merge($baseManipulations, $manipulations);
+
+    $imgService = img($src, $width, $height, $baseManipulations);
 
     if ($sizes) {
         $srcSet = collect($defaultWidths)->map(fn($w) => $imgService->url(['w' => $w]) . " {$w}w")->implode(', ');

--- a/src/Http/Controllers/ImageController.php
+++ b/src/Http/Controllers/ImageController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
+use Itiden\Opixlig\Utils\Manipulations;
 use League\Glide\ServerFactory;
 use League\Glide\Signatures\SignatureFactory;
 
@@ -15,14 +16,7 @@ final class ImageController
     {
         $signKey = Config::get('app.key');
 
-        $manipArray = collect(explode('_', $manipulations))
-            ->mapWithKeys(function ($pair) {
-                [$key, $value] = explode('-', $pair, 2);
-
-                return [$key => $value];
-            })
-            ->toArray();
-        ksort($manipArray);
+        $manipArray = Manipulations::parse($manipulations);
 
         SignatureFactory::create($signKey)->validateRequest(
             $request->path(),

--- a/src/Http/Controllers/ImageController.php
+++ b/src/Http/Controllers/ImageController.php
@@ -15,10 +15,9 @@ final class ImageController
     {
         $signKey = Config::get('app.key');
 
-        $manipArray = collect(explode('-', $manipulations))
-            ->chunk(2)
+        $manipArray = collect(explode('_', $manipulations))
             ->mapWithKeys(function ($pair) {
-                [$key, $value] = $pair->values();
+                [$key, $value] = explode('-', $pair, 2);
 
                 return [$key => $value];
             })

--- a/src/Services/ImageService.php
+++ b/src/Services/ImageService.php
@@ -3,6 +3,7 @@
 namespace Itiden\Opixlig\Services;
 
 use Illuminate\Support\Facades\Config;
+use Itiden\Opixlig\Utils\Manipulations;
 use League\Glide\Signatures\SignatureFactory;
 
 final class ImageService
@@ -23,7 +24,7 @@ final class ImageService
         $extension = $manipulations['fm'] ?? pathinfo($src, PATHINFO_EXTENSION);
         $filenameWithExtension = "{$filename}.{$extension}";
 
-        $manipString = $this->stringifyManipulations($manipulations);
+        $manipString = Manipulations::stringify($manipulations);
         $trimmedSrc = ltrim($src, '/');
         $publicFolder = Config::get('opixlig.public_folder');
         $path = "$publicFolder/$trimmedSrc/{$manipString}/{$filenameWithExtension}";
@@ -49,29 +50,5 @@ final class ImageService
         $css = "background-image:{$svg};background-size:cover;background-position:center;background-repeat:no-repeat;";
 
         return $css;
-    }
-
-    private function stringifyManipulations(array $manipulations): string
-    {
-        ksort($manipulations);
-
-        return collect($manipulations)
-            ->map(fn ($value, $key) => "{$key}-{$value}")
-            ->implode('_');
-    }
-
-    private function parseManipulationsString(string $manipulations): array
-    {
-        $manipulations = collect(explode('_', $manipulations))
-            ->mapWithKeys(function ($pair) {
-                [$key, $value] = explode('-', $pair, 2);
-
-                return [$key => $value];
-            })
-            ->toArray();
-
-        ksort($manipulations);
-
-        return $manipulations;
     }
 }

--- a/src/Services/ImageService.php
+++ b/src/Services/ImageService.php
@@ -57,15 +57,14 @@ final class ImageService
 
         return collect($manipulations)
             ->map(fn ($value, $key) => "{$key}-{$value}")
-            ->implode('-');
+            ->implode('_');
     }
 
     private function parseManipulationsString(string $manipulations): array
     {
-        $manipulations = collect(explode('-', $manipulations))
-            ->chunk(2)
+        $manipulations = collect(explode('_', $manipulations))
             ->mapWithKeys(function ($pair) {
-                [$key, $value] = $pair->values();
+                [$key, $value] = explode('-', $pair, 2);
 
                 return [$key => $value];
             })

--- a/src/Utils/Manipulations.php
+++ b/src/Utils/Manipulations.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Itiden\Opixlig\Utils;
+
+final class Manipulations
+{
+    /**
+     * Convert a manipulations array to a URL-safe string.
+     *
+     * Format: key-value pairs joined by underscores (e.g. "fit-crop-center_fm-webp_q-75").
+     * Underscores separate pairs, first dash separates key from value.
+     *
+     * @param  array<string, mixed>  $manipulations
+     */
+    public static function stringify(array $manipulations): string
+    {
+        ksort($manipulations);
+
+        return collect($manipulations)
+            ->map(fn ($value, $key) => "{$key}-{$value}")
+            ->implode('_');
+    }
+
+    /**
+     * Parse a manipulation string back into an associative array.
+     *
+     * @return array<string, string>
+     */
+    public static function parse(string $manipulations): array
+    {
+        $manipulations = collect(explode('_', $manipulations))
+            ->mapWithKeys(function ($pair) {
+                [$key, $value] = explode('-', $pair, 2);
+
+                return [$key => $value];
+            })
+            ->toArray();
+
+        ksort($manipulations);
+
+        return $manipulations;
+    }
+}

--- a/tests/Feature.php
+++ b/tests/Feature.php
@@ -1,5 +1,0 @@
-<?php
-
-it('foo', function (): void {
-    expect(true)->toBe(true);
-});

--- a/tests/Feature/DeleteCachedImageTest.php
+++ b/tests/Feature/DeleteCachedImageTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\File;
+use Itiden\Opixlig\Jobs\DeleteCachedImage;
+
+it('can be instantiated with container and path', function (): void {
+    $job = new DeleteCachedImage('public', 'images/photo.jpg');
+
+    expect($job->container)->toBe('public')
+        ->and($job->path)->toBe('images/photo.jpg');
+});
+
+it('deletes the cache directory when it exists', function (): void {
+    $storageFolder = Config::get('opixlig.storage_folder');
+    $cacheDir = storage_path("{$storageFolder}/public/images");
+
+    File::ensureDirectoryExists($cacheDir);
+    File::put("{$cacheDir}/cached.jpg", 'fake image');
+
+    expect(File::isDirectory($cacheDir))->toBeTrue();
+
+    $job = new DeleteCachedImage('public', 'images');
+    $job->handle();
+
+    expect(File::isDirectory($cacheDir))->toBeFalse();
+});
+
+it('does nothing when the cache directory does not exist', function (): void {
+    $storageFolder = Config::get('opixlig.storage_folder');
+    $cacheDir = storage_path("{$storageFolder}/public/nonexistent");
+
+    expect(File::isDirectory($cacheDir))->toBeFalse();
+
+    $job = new DeleteCachedImage('public', 'nonexistent');
+    $job->handle();
+
+    expect(File::isDirectory($cacheDir))->toBeFalse();
+});

--- a/tests/Feature/HelperTest.php
+++ b/tests/Feature/HelperTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Itiden\Opixlig\Services\ImageService;
+
+it('returns an ImageService instance', function (): void {
+    $service = img('public/images/hero.jpg', 800, 600, ['fm' => 'webp']);
+
+    expect($service)->toBeInstanceOf(ImageService::class);
+});
+
+it('passes src, width, height and base manipulations to ImageService', function (): void {
+    $service = img('/public/gallery/photo.jpg?cache=123', 320, 240, [
+        'fm' => 'avif',
+        'q' => 70,
+    ]);
+
+    $reflection = new ReflectionClass($service);
+
+    $src = $reflection->getProperty('src');
+    $width = $reflection->getProperty('width');
+    $height = $reflection->getProperty('height');
+    $baseManipulations = $reflection->getProperty('baseManipulations');
+
+    expect($src->getValue($service))->toBe('/public/gallery/photo.jpg')
+        ->and($width->getValue($service))->toBe(320)
+        ->and($height->getValue($service))->toBe(240)
+        ->and($baseManipulations->getValue($service))->toBe([
+            'fm' => 'avif',
+            'q' => 70,
+        ]);
+});

--- a/tests/Feature/ImageComponentTest.php
+++ b/tests/Feature/ImageComponentTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use Illuminate\Support\Facades\Blade;
+
+it('renders an img tag with expected base attributes', function (): void {
+    $html = Blade::render('<x-opixlig::image src="public/images/example.jpg" width="320" height="180" alt="Example image" />');
+
+    expect($html)
+        ->toContain('<img')
+        ->toContain('alt="Example image"')
+        ->toContain('src="http://localhost/images/public/images/example.jpg/')
+        ->toContain('width="320"')
+        ->toContain('height="180"');
+});
+
+it('does not include fit in manipulation string when fit is empty', function (): void {
+    $html = Blade::render('<x-opixlig::image src="public/images/example.jpg" width="320" height="180" />');
+
+    expect($html)
+        ->toContain('fm-webp')
+        ->toContain('q-75')
+        ->not->toContain('fit-');
+});
+
+it('includes fit in manipulation string when fit is set', function (): void {
+    $html = Blade::render('<x-opixlig::image src="public/images/example.jpg" width="320" height="180" fit="crop-center" />');
+
+    expect($html)->toContain('fit-crop-center');
+});
+
+it('includes focal point fit values in manipulation string', function (): void {
+    $html = Blade::render('<x-opixlig::image src="public/images/example.jpg" width="320" height="180" fit="crop-44-13-1" />');
+
+    expect($html)->toContain('fit-crop-44-13-1');
+});
+
+it('merges additional manipulations into the manipulation string', function (): void {
+    $template = <<<'BLADE'
+<x-opixlig::image
+    src="public/images/example.jpg"
+    width="320"
+    height="180"
+    :manipulations="['blur' => 10, 'bri' => 20]"
+/>
+BLADE;
+
+    $html = Blade::render($template);
+
+    expect($html)
+        ->toContain('blur-10')
+        ->toContain('bri-20')
+        ->toContain('fm-webp')
+        ->toContain('q-75');
+});
+
+it('supports custom format and quality values in manipulation string', function (): void {
+    $html = Blade::render('<x-opixlig::image src="public/images/example.jpg" width="320" height="180" format="avif" quality="60" />');
+
+    expect($html)
+        ->toContain('fm-avif')
+        ->toContain('q-60');
+});
+
+it('generates responsive srcset with width descriptors when sizes is provided', function (): void {
+    $html = Blade::render('<x-opixlig::image src="public/images/example.jpg" width="800" height="600" sizes="(max-width: 768px) 100vw, 50vw" />');
+
+    expect($html)
+        ->toContain('sizes="(max-width: 768px) 100vw, 50vw"')
+        ->toContain('srcset="')
+        ->toContain(' 384w')
+        ->toContain(' 3840w');
+});
+
+it('generates fixed width srcset with 1x and 2x descriptors', function (): void {
+    $html = Blade::render('<x-opixlig::image src="public/images/example.jpg" width="300" height="150" />');
+
+    expect($html)
+        ->toContain('srcset="')
+        ->toContain(' 1x')
+        ->toContain(' 2x')
+        ->toContain('w-300')
+        ->toContain('w-600');
+});
+
+it('renders loading and decoding attributes', function (): void {
+    $html = Blade::render('<x-opixlig::image src="public/images/example.jpg" width="300" height="150" loading="eager" decoding="sync" />');
+
+    expect($html)
+        ->toContain('loading="eager"')
+        ->toContain('decoding="sync"');
+});
+
+it('does not render placeholder style when placeholder is empty', function (): void {
+    $html = Blade::render('<x-opixlig::image src="public/images/example.jpg" width="300" height="150" placeholder="empty" />');
+
+    expect($html)->not->toContain('style=');
+});
+
+it('passes additional HTML attributes through to the img tag', function (): void {
+    $html = Blade::render('<x-opixlig::image src="public/images/example.jpg" width="300" height="150" class="rounded" id="hero" />');
+
+    expect($html)
+        ->toContain('class="rounded"')
+        ->toContain('id="hero"');
+});

--- a/tests/Feature/ImageComponentTest.php
+++ b/tests/Feature/ImageComponentTest.php
@@ -68,7 +68,9 @@ it('generates responsive srcset with width descriptors when sizes is provided', 
         ->toContain('sizes="(max-width: 768px) 100vw, 50vw"')
         ->toContain('srcset="')
         ->toContain(' 384w')
-        ->toContain(' 3840w');
+        ->toContain('h-288')
+        ->toContain(' 3840w')
+        ->toContain('h-2880');
 });
 
 it('generates fixed width srcset with 1x and 2x descriptors', function (): void {
@@ -79,7 +81,9 @@ it('generates fixed width srcset with 1x and 2x descriptors', function (): void 
         ->toContain(' 1x')
         ->toContain(' 2x')
         ->toContain('w-300')
-        ->toContain('w-600');
+        ->toContain('h-150')
+        ->toContain('w-600')
+        ->toContain('h-300');
 });
 
 it('renders loading and decoding attributes', function (): void {

--- a/tests/Feature/ImageControllerTest.php
+++ b/tests/Feature/ImageControllerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+
+it('serves a processed image with valid signature', function (): void {
+    if (! function_exists('imagecreatetruecolor')) {
+        $this->markTestSkipped('GD extension is required.');
+    }
+
+    $resource = imagecreatetruecolor(10, 10);
+    $red = imagecolorallocate($resource, 255, 0, 0);
+    imagefill($resource, 0, 0, $red);
+
+    ob_start();
+    imagejpeg($resource);
+    $image = (string) ob_get_clean();
+    imagedestroy($resource);
+
+    Storage::disk('public')->put('images/photo.jpg', $image);
+
+    $service = img('public/images/photo.jpg', 100, 100, ['fm' => 'jpg', 'q' => 75]);
+    $url = $service->url(['w' => 100]);
+
+    $response = $this->get(parse_url($url, PHP_URL_PATH).'?'.parse_url($url, PHP_URL_QUERY));
+
+    $response->assertOk();
+    $response->assertHeader('content-type', 'image/jpeg');
+});
+
+it('rejects requests with invalid signature', function (): void {
+    $publicFolder = Config::get('opixlig.public_folder');
+
+    $this->withoutExceptionHandling();
+
+    $this->get("/{$publicFolder}/public/images/photo.jpg/fm-webp-q-75-w-800/photo.webp?s=invalidsignature");
+})->throws(\League\Glide\Signatures\SignatureException::class);
+
+it('serves an image with multiple manipulations in the URL', function (): void {
+    if (! function_exists('imagecreatetruecolor')) {
+        $this->markTestSkipped('GD extension is required.');
+    }
+
+    $resource = imagecreatetruecolor(10, 10);
+    $blue = imagecolorallocate($resource, 0, 0, 255);
+    imagefill($resource, 0, 0, $blue);
+
+    ob_start();
+    imagejpeg($resource);
+    $image = (string) ob_get_clean();
+    imagedestroy($resource);
+
+    Storage::disk('public')->put('images/multi.jpg', $image);
+
+    $service = img('public/images/multi.jpg', 200, 200, ['fm' => 'jpg', 'q' => 90, 'fit' => 'crop']);
+    $url = $service->url(['w' => 200]);
+
+    $response = $this->get(parse_url($url, PHP_URL_PATH).'?'.parse_url($url, PHP_URL_QUERY));
+
+    $response->assertOk();
+});

--- a/tests/Feature/ImageControllerTest.php
+++ b/tests/Feature/ImageControllerTest.php
@@ -33,7 +33,7 @@ it('rejects requests with invalid signature', function (): void {
 
     $this->withoutExceptionHandling();
 
-    $this->get("/{$publicFolder}/public/images/photo.jpg/fm-webp-q-75-w-800/photo.webp?s=invalidsignature");
+    $this->get("/{$publicFolder}/public/images/photo.jpg/fm-webp_q-75_w-800/photo.webp?s=invalidsignature");
 })->throws(\League\Glide\Signatures\SignatureException::class);
 
 it('serves an image with multiple manipulations in the URL', function (): void {

--- a/tests/Feature/ImageServiceTest.php
+++ b/tests/Feature/ImageServiceTest.php
@@ -40,7 +40,7 @@ it('builds a signed URL with merged and sorted manipulations', function (): void
     ];
 
     expect($path)
-        ->toBe('/images/public/images/hero.jpg/blur-10-fit-crop-fm-webp-q-60-w-800/hero.webp');
+        ->toBe('/images/public/images/hero.jpg/blur-10_fit-crop_fm-webp_q-60_w-800/hero.webp');
 
     $expectedSignature = SignatureFactory::create(Config::get('app.key'))
         ->addSignature((string) $path, $expectedManipulations)['s'];
@@ -61,7 +61,7 @@ it('handles URL-style src values via parse_url in the constructor', function ():
     $path = parse_url($url, PHP_URL_PATH);
 
     expect($path)
-        ->toBe('/images/public/gallery/photo.jpeg/fm-avif-w-640/photo.avif');
+        ->toBe('/images/public/gallery/photo.jpeg/fm-avif_w-640/photo.avif');
 });
 
 it('returns an empty placeholder for empty type', function (): void {

--- a/tests/Feature/ImageServiceTest.php
+++ b/tests/Feature/ImageServiceTest.php
@@ -1,0 +1,153 @@
+<?php
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+use Itiden\Opixlig\Services\ImageService;
+use League\Glide\Signatures\SignatureFactory;
+
+it('builds a signed URL with merged and sorted manipulations', function (): void {
+    $baseManipulations = [
+        'q' => 75,
+        'fm' => 'webp',
+        'fit' => 'crop',
+    ];
+
+    $urlManipulations = [
+        'w' => 800,
+        'q' => 60,
+        'blur' => 10,
+    ];
+
+    $service = new ImageService(
+        src: 'public/images/hero.jpg',
+        width: 1200,
+        height: 800,
+        baseManipulations: $baseManipulations,
+    );
+
+    $url = $service->url($urlManipulations);
+    $path = parse_url($url, PHP_URL_PATH);
+    $query = parse_url($url, PHP_URL_QUERY);
+
+    parse_str(is_string($query) ? $query : '', $queryParams);
+
+    $expectedManipulations = [
+        'q' => 60,
+        'fm' => 'webp',
+        'fit' => 'crop',
+        'w' => 800,
+        'blur' => 10,
+    ];
+
+    expect($path)
+        ->toBe('/images/public/images/hero.jpg/blur-10-fit-crop-fm-webp-q-60-w-800/hero.webp');
+
+    $expectedSignature = SignatureFactory::create(Config::get('app.key'))
+        ->addSignature((string) $path, $expectedManipulations)['s'];
+
+    expect($queryParams)
+        ->toHaveKey('s', $expectedSignature);
+});
+
+it('handles URL-style src values via parse_url in the constructor', function (): void {
+    $service = new ImageService(
+        src: 'https://cdn.example.com/public/gallery/photo.jpeg?token=abc123',
+        width: 640,
+        height: 480,
+        baseManipulations: ['fm' => 'avif'],
+    );
+
+    $url = $service->url(['w' => 640]);
+    $path = parse_url($url, PHP_URL_PATH);
+
+    expect($path)
+        ->toBe('/images/public/gallery/photo.jpeg/fm-avif-w-640/photo.avif');
+});
+
+it('returns an empty placeholder for empty type', function (): void {
+    $service = new ImageService(
+        src: 'public/images/hero.jpg',
+        width: 1200,
+        height: 800,
+        baseManipulations: [],
+    );
+
+    expect($service->placeholder('empty'))->toBe('');
+});
+
+it('returns blur placeholder CSS when blur type is requested', function (): void {
+    if (! function_exists('imagecreatetruecolor')) {
+        $this->markTestSkipped('GD extension is required to create an image fixture.');
+    }
+
+    $resource = imagecreatetruecolor(2, 2);
+    $red = imagecolorallocate($resource, 255, 0, 0);
+    imagefill($resource, 0, 0, $red);
+
+    ob_start();
+    imagepng($resource);
+    $image = (string) ob_get_clean();
+    imagedestroy($resource);
+
+    Storage::disk('public')->put('opixlig-tests/sample.png', $image);
+
+    $service = new ImageService(
+        src: 'public/opixlig-tests/sample.png',
+        width: 400,
+        height: 300,
+        baseManipulations: [],
+    );
+
+    $placeholder = $service->placeholder('blur');
+
+    expect($placeholder)
+        ->toStartWith('background-image:url("data:image/svg+xml;charset=utf-8,')
+        ->toContain('background-size:cover;')
+        ->toContain('background-position:center;')
+        ->toContain('background-repeat:no-repeat;');
+});
+
+it('falls back to file extension when fm is not in manipulations', function (): void {
+    $service = new ImageService(
+        src: 'public/images/photo.png',
+        width: 800,
+        height: 600,
+        baseManipulations: ['q' => 80],
+    );
+
+    $url = $service->url(['w' => 400]);
+    $path = parse_url($url, PHP_URL_PATH);
+
+    expect($path)->toContain('/photo.png');
+});
+
+it('uses fm extension for filename when fm is in manipulations', function (): void {
+    $service = new ImageService(
+        src: 'public/images/photo.png',
+        width: 800,
+        height: 600,
+        baseManipulations: ['fm' => 'webp'],
+    );
+
+    $url = $service->url(['w' => 400]);
+    $path = parse_url($url, PHP_URL_PATH);
+
+    expect($path)->toContain('/photo.webp');
+});
+
+it('allows url manipulations to override base manipulations', function (): void {
+    $service = new ImageService(
+        src: 'public/images/hero.jpg',
+        width: 800,
+        height: 600,
+        baseManipulations: ['fm' => 'webp', 'q' => 75],
+    );
+
+    $url = $service->url(['fm' => 'avif', 'w' => 800]);
+    $path = parse_url($url, PHP_URL_PATH);
+
+    expect($path)
+        ->toContain('fm-avif')
+        ->toContain('/hero.avif')
+        ->not->toContain('fm-webp');
+});

--- a/tests/Feature/ManipulationsTest.php
+++ b/tests/Feature/ManipulationsTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use Itiden\Opixlig\Utils\Manipulations;
+
+it('stringifies simple manipulations sorted by key', function (): void {
+    $result = Manipulations::stringify([
+        'w' => 800,
+        'fm' => 'webp',
+        'q' => 75,
+    ]);
+
+    expect($result)->toBe('fm-webp_q-75_w-800');
+});
+
+it('stringifies manipulations with dashes in values', function (): void {
+    $result = Manipulations::stringify([
+        'fit' => 'crop-center',
+        'fm' => 'webp',
+        'q' => 75,
+    ]);
+
+    expect($result)->toBe('fit-crop-center_fm-webp_q-75');
+});
+
+it('stringifies focal point fit values correctly', function (): void {
+    $result = Manipulations::stringify([
+        'fit' => 'crop-44-13-1',
+        'fm' => 'webp',
+        'w' => 800,
+    ]);
+
+    expect($result)->toBe('fit-crop-44-13-1_fm-webp_w-800');
+});
+
+it('parses a simple manipulation string', function (): void {
+    $result = Manipulations::parse('fm-webp_q-75_w-800');
+
+    expect($result)->toBe([
+        'fm' => 'webp',
+        'q' => '75',
+        'w' => '800',
+    ]);
+});
+
+it('parses manipulation string with dashes in values', function (): void {
+    $result = Manipulations::parse('fit-crop-center_fm-webp_q-75');
+
+    expect($result)->toBe([
+        'fit' => 'crop-center',
+        'fm' => 'webp',
+        'q' => '75',
+    ]);
+});
+
+it('parses focal point fit values correctly', function (): void {
+    $result = Manipulations::parse('fit-crop-44-13-1_fm-webp_w-800');
+
+    expect($result)->toBe([
+        'fit' => 'crop-44-13-1',
+        'fm' => 'webp',
+        'w' => '800',
+    ]);
+});
+
+it('roundtrips stringify then parse', function (): void {
+    $original = [
+        'fit' => 'crop-bottom-right',
+        'fm' => 'avif',
+        'q' => 90,
+        'w' => 1200,
+    ];
+
+    $string = Manipulations::stringify($original);
+    $parsed = Manipulations::parse($string);
+
+    expect($parsed)->toBe([
+        'fit' => 'crop-bottom-right',
+        'fm' => 'avif',
+        'q' => '90',
+        'w' => '1200',
+    ]);
+});
+
+it('parses fill-max fit value correctly', function (): void {
+    $result = Manipulations::parse('fit-fill-max_fm-webp');
+
+    expect($result)->toBe([
+        'fit' => 'fill-max',
+        'fm' => 'webp',
+    ]);
+});

--- a/tests/Feature/ServiceProviderTest.php
+++ b/tests/Feature/ServiceProviderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\View;
+use Itiden\Opixlig\Http\Controllers\ImageController;
+
+it('has merged opixlig configuration values available', function (): void {
+    expect(Config::get('opixlig.storage_folder'))->toBe('app/opixlig')
+        ->and(Config::get('opixlig.public_folder'))->toBe('images')
+        ->and(Config::get('opixlig.default_quality'))->toBe(75)
+        ->and(Config::get('opixlig.default_format'))->toBe('webp');
+});
+
+it('registers the opixlig view namespace', function (): void {
+    expect(View::exists('opixlig::components.image'))->toBeTrue();
+
+    $hints = $this->app['view']->getFinder()->getHints();
+
+    expect($hints)->toHaveKey('opixlig');
+});
+
+it('registers the image route', function (): void {
+    $route = collect($this->app['router']->getRoutes()->getRoutes())->first(fn ($candidate): bool => $candidate->uri() === 'images/{fullpath}/{manipulations}/{filename}'
+        && in_array('GET', $candidate->methods(), true)
+        && $candidate->getActionName() === ImageController::class);
+
+    expect($route)->not->toBeNull();
+});
+
+it('merges filesystem links configuration for public image cache', function (): void {
+    $links = Config::get('filesystems.links', []);
+    $publicPath = $this->app->publicPath('images');
+
+    expect($links)->toHaveKey($publicPath)
+        ->and($links[$publicPath])->toBe($this->app->storagePath('app/opixlig'));
+});

--- a/tests/Feature/StatamicAssetSubscriberTest.php
+++ b/tests/Feature/StatamicAssetSubscriberTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Support\Facades\Bus;
+use Itiden\Opixlig\Jobs\DeleteCachedImage;
+use Itiden\Opixlig\Listeners\StatamicAssetSubscriber;
+
+it('dispatches DeleteCachedImage job for image assets', function (): void {
+    Bus::fake();
+
+    $event = new stdClass;
+    $event->asset = new stdClass;
+    $event->asset->path = 'photos/hero.jpg';
+    $event->asset->is_image = true;
+    $event->asset->container = new stdClass;
+    $event->asset->container->handle = 'assets';
+
+    $subscriber = new StatamicAssetSubscriber;
+    $subscriber->handle($event);
+
+    Bus::assertDispatched(DeleteCachedImage::class, fn ($job): bool => $job->container === 'assets' && $job->path === 'photos/hero.jpg');
+});
+
+it('skips non-image assets', function (): void {
+    Bus::fake();
+
+    $event = new stdClass;
+    $event->asset = new stdClass;
+    $event->asset->path = 'documents/readme.pdf';
+    $event->asset->is_image = false;
+    $event->asset->container = new stdClass;
+    $event->asset->container->handle = 'assets';
+
+    $subscriber = new StatamicAssetSubscriber;
+    $subscriber->handle($event);
+
+    Bus::assertNotDispatched(DeleteCachedImage::class);
+});
+
+it('subscribes to Statamic asset events', function (): void {
+    $subscriber = new StatamicAssetSubscriber;
+    $dispatcher = app(Illuminate\Events\Dispatcher::class);
+
+    $subscriber->subscribe($dispatcher);
+
+    expect($dispatcher->hasListeners('Statamic\Events\AssetDeleted'))->toBeTrue()
+        ->and($dispatcher->hasListeners('Statamic\Events\AssetSaved'))->toBeTrue();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+use Tests\TestCase;
+
+uses(TestCase::class)->in('Feature');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests;
+
+use Itiden\Opixlig\OpixligServiceProvider;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+
+abstract class TestCase extends OrchestraTestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [
+            OpixligServiceProvider::class,
+        ];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('app.key', 'base64:dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdGtleTE=');
+        $app['config']->set('opixlig.storage_folder', 'app/opixlig');
+        $app['config']->set('opixlig.public_folder', 'images');
+        $app['config']->set('opixlig.driver', 'gd');
+        $app['config']->set('opixlig.default_widths', [384, 640, 828, 1200, 1920, 2048, 3840]);
+        $app['config']->set('opixlig.default_placeholder', 'empty');
+        $app['config']->set('opixlig.default_quality', 75);
+        $app['config']->set('opixlig.default_format', 'webp');
+    }
+}


### PR DESCRIPTION
This pull request introduces enhanced image manipulation capabilities to the Blade image component and helper, expands test coverage for image processing, and improves documentation for users. The most important changes are the addition of `fit` and `manipulations` props for advanced image control, comprehensive tests for the new features, and detailed updates to the documentation to help developers use these options.

### Image manipulation enhancements

* Added support for `fit` and `manipulations` props to the Blade image component, allowing users to crop, resize, and apply additional Glide manipulations (e.g., blur, brightness, filters) directly from Blade views. (`resources/views/components/image.blade.php`)
* Updated the `img()` helper and its usage to merge base manipulations and additional manipulations for flexible image processing. (`resources/views/components/image.blade.php`)

### Documentation improvements

* Expanded the `README.md` to document the new `fit` and `manipulations` props, provide usage examples, and list all supported Glide manipulation parameters. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R114-R137) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R161-R204)
* Clarified available props table and manipulation parameter descriptions for better developer guidance. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127-R151) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R161-R204)

### Test coverage expansion

* Added feature tests to verify the Blade image component's rendering, manipulation merging, responsive `srcset`, placeholder handling, and HTML attribute passthrough. (`tests/Feature/ImageComponentTest.php`)
* Added tests for the `img()` helper and `ImageService` to ensure correct parameter passing, manipulation merging, URL generation, placeholder logic, and file extension handling. (`tests/Feature/HelperTest.php`, `tests/Feature/ImageServiceTest.php`) [[1]](diffhunk://#diff-23158136ec79f738d91187535c032afbd75e721ba9352183bd11e7cee469a1b6R1-R31) [[2]](diffhunk://#diff-f24f0f2a4d7990600663f2d20ce5088715a4a474037ecb54544e724eae4416a2R1-R153)
* Added tests for image controller endpoints to verify image serving, signature validation, and manipulation combinations. (`tests/Feature/ImageControllerTest.php`)
* Added tests for cache deletion job logic. (`tests/Feature/DeleteCachedImageTest.php`)

### CI configuration update

* Modified GitHub Actions workflow to test only on `ubuntu-latest` and added PHP versions `8.3`, `8.4`, and `8.5` for broader compatibility. (`.github/workflows/tests.yml`)

### Dependency additions

* Added `orchestra/testbench` as a dev dependency for improved Laravel package testing. (`composer.json`)